### PR TITLE
NCURSES_RENTRANT fix (closes #2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ if (USE_NCURSES)
 		set(CMAKE_REQUIRED_LIBRARIES ncurses)
 		CHECK_C_SOURCE_COMPILES("${ncurses_not_reentrant_check}" NCURSES_NOT_REENTRANT)
 
-		if (NCURSES_NOT_REENTRANT)
+		if (TRUE)
 			# HACK: We should use ${CURSES_LIBRARIES} here, but that breaks static
 			# builds as it contains the full path to ncurses.so
 			target_link_libraries(cfunge ncurses)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,44 +354,18 @@ if (USE_NCURSES)
 	CHECK_INCLUDE_FILE(ncurses/term.h HAVE_NCURSES_TERM_H)
 
 	if (CURSES_FOUND AND (HAVE_TERM_H OR HAVE_NCURSES_TERM_H) AND (CURSES_HAVE_CURSES_H OR CURSES_HAVE_NCURSES_CURSES_H))
-		# Check that we're not using reentrant ncurses
-		set(ncurses_not_reentrant_check
-			"int main() {
-				#if NCURSES_REENTRANT
-				#error
-				#endif
-				curscr = NULL;
-				return 0;
-			}")
-		if (CURSES_HAVE_CURSES_H)
-			set(ncurses_not_reentrant_check
-			    "#include <curses.h>
-			    ${ncurses_not_reentrant_check}")
-		elseif (CURSES_HAVE_NCURSES_CURSES_H)
-			set(ncurses_not_reentrant_check
-			    "#include <ncurses/curses.h>
-			    ${ncurses_not_reentrant_check}")
+		# HACK: We should use ${CURSES_LIBRARIES} here, but that breaks static
+		# builds as it contains the full path to ncurses.so
+		target_link_libraries(cfunge ncurses)
+		add_definitions(-DHAVE_NCURSES)
+		if (HAVE_NCURSES_TERM_H)
+			add_definitions(-DTERM_H_IN_NCURSES)
 		endif ()
-
-		set(CMAKE_REQUIRED_LIBRARIES ncurses)
-		CHECK_C_SOURCE_COMPILES("${ncurses_not_reentrant_check}" NCURSES_NOT_REENTRANT)
-
-		if (TRUE)
-			# HACK: We should use ${CURSES_LIBRARIES} here, but that breaks static
-			# builds as it contains the full path to ncurses.so
-			target_link_libraries(cfunge ncurses)
-			add_definitions(-DHAVE_NCURSES)
-			if (HAVE_NCURSES_TERM_H)
-				add_definitions(-DTERM_H_IN_NCURSES)
-			endif ()
-			if (CURSES_HAVE_NCURSES_CURSES_H)
-				add_definitions(-DCURSES_H_IN_NCURSES)
-			endif ()
-			if (CURSES_HAVE_NCURSES_NCURSES_H)
-				add_definitions(-DNCURSES_H_IN_NCURSES)
-			endif ()
-		else ()
-			message(STATUS "ncurses has NCURSES_REENTRANT, which is not supported: disabling the TERM fingerprint")
+		if (CURSES_HAVE_NCURSES_CURSES_H)
+			add_definitions(-DCURSES_H_IN_NCURSES)
+		endif ()
+		if (CURSES_HAVE_NCURSES_NCURSES_H)
+			add_definitions(-DNCURSES_H_IN_NCURSES)
 		endif ()
 	else()
 		message(STATUS "ncurses and/or term.h not found: disabling the TERM fingerprint.")

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ don't. For example:
  * Ncurses (http://www.gnu.org/software/ncurses/), needed for the TERM
    fingerprint. This is most likely already installed, though headers may need
    to be installed separately via some form of -dev package. Ncurses will be
-   automatically used if found. Reentrant ncurses is not supported and support
-   will be skipped if detected.
+   automatically used if found.
  * IEC 60559 floating-point arithmetic. Please see Annex F in ISO/IEC 9899 for
    more details.
  * LibBSD (or have a BSD libc). This allows using arc4random which provides

--- a/src/fingerprints/NCRS/NCRS.c
+++ b/src/fingerprints/NCRS/NCRS.c
@@ -129,24 +129,18 @@ static void finger_NCRS_get(instructionPointer * ip)
 static void finger_NCRS_init(instructionPointer * ip)
 {
 	if (stack_pop(ip->stack) == 1) {
-		// We can only initialise once per session.
-		if (!ncrs_initialised) {
-			// If TERM was used before, check to make sure we don't get a mem
-			// leak:
-			finger_TERM_fix_before_NCRS_init();
-			ncrs_screen = newterm(NULL, stdout, stdin);
-			if (!ncrs_screen)
-				goto error;
-			set_term(ncrs_screen);
-			ncrs_window = newwin(0, 0, 0, 0);
-			if (!ncrs_window)
-				goto error;
-			stdscr = ncrs_window;
-			ncrs_initialised = true;
-			ncrs_valid_state = true;
-		} else {
+		// If TERM was used before, check to make sure we don't get a mem
+		// leak:
+		finger_TERM_fix_before_NCRS_init();
+		ncrs_screen = newterm(NULL, stdout, stdin);
+		if (!ncrs_screen)
 			goto error;
-		}
+		set_term(ncrs_screen);
+		ncrs_window = newwin(0, 0, 0, 0);
+		if (!ncrs_window)
+			goto error;
+		ncrs_initialised = true;
+		ncrs_valid_state = true;
 	} else {
 		if (!ncrs_initialised)
 			goto error;
@@ -227,7 +221,7 @@ static void finger_NCRS_put(instructionPointer * ip)
 static void finger_NCRS_refresh(instructionPointer * ip)
 {
 	NCRS_VALIDATE_STATE();
-	if (refresh() == ERR)
+	if (wrefresh(ncrs_window) == ERR)
 		ip_reverse(ip);
 }
 

--- a/src/fingerprints/TERM/TERM.c
+++ b/src/fingerprints/TERM/TERM.c
@@ -173,9 +173,7 @@ void finger_TERM_fix_before_NCRS_init(void)
 {
 	if (!term_initialised)
 		return;
-	assert(cur_term != NULL);
 	del_curterm(cur_term);
-	cur_term = NULL;
 }
 
 FUNGE_ATTR_FAST
@@ -184,8 +182,7 @@ void finger_TERM_fix_after_NCRS_teardown(void)
 	int errret;
 	if (!term_initialised)
 		return;
-	assert(cur_term == NULL);
-	// Now terminal is invalid, redo setupterm()
+	// Now terminal is potentially invalid, redo setupterm()
 	if (setupterm(NULL, STDOUT_FILENO, &errret) != OK && errret <= 0)
 		return;
 }


### PR DESCRIPTION
I've looked through some ncurses tutorials and `man` pages, and as far as I can tell the main thing assigning to `stdscr` does is to change which `WINDOW*` is used by default – almost all ncurses functions have a variant that takes a `WINDOW*`, and one that doesn't.

If I'm right about that, then we don't have to care about `stdscr` if we always use the functions we can pass our own `WINDOW* ncrs_window` to. I could only find one instance where a non-`w` function was called: `refresh()`, which I've replaced by `wrefresh(ncrs_window)`

As for `cur_term` – this was only set to `NULL`, right after calling `del_curterm`. While this looks like good housekeeping, I don't think it actually ever made a difference, so I took it out.

During testing I noticed that entering and exiting ncurses mode repeatedly was disabled in the code, but now that I've removed the `if` guard in `finger_NCRS_init()` it appears to work just fine.

NB these changes are pretty poorly tested.